### PR TITLE
Support sm2 double certs

### DIFF
--- a/crypto/cert_test.go
+++ b/crypto/cert_test.go
@@ -16,6 +16,8 @@ package crypto
 
 import (
 	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -38,6 +40,28 @@ func TestCertGenerate(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := cert.Sign(key, EVP_SHA256); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCertGenerateSM2(t *testing.T) {
+	key, err := GenerateECKey(Sm2Curve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := &CertificateInfo{
+		Serial:       big.NewInt(int64(1)),
+		Issued:       0,
+		Expires:      24 * time.Hour,
+		Country:      "US",
+		Organization: "Test",
+		CommonName:   "localhost",
+	}
+	cert, err := NewCertificate(info, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cert.Sign(key, EVP_SM3); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -98,6 +122,127 @@ func TestCAGenerate(t *testing.T) {
 	}
 	if err := cert.Sign(cakey, EVP_SHA256); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCAGenerateSM2(t *testing.T) {
+	dirName := filepath.Join("test-runs", "TestCAGenerateSM2")
+	_, err := os.Stat(dirName)
+	if os.IsNotExist(err) {
+		// The directory does not exist, creating it now.
+		err := os.MkdirAll(dirName, 0755)
+		if err != nil {
+			t.Logf("Failed to create the directory: %v\n", err)
+		}
+	} else if err != nil {
+		// other error
+		t.Logf("Failed to check the directory: %v\n", err)
+	}
+
+	// Helper function: generate and save key
+	generateAndSaveKey := func(filename string) PrivateKey {
+		key, err := GenerateECKey(Sm2Curve)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pem, err := key.MarshalPKCS8PrivateKeyPEM()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = SavePEMToFile(pem, filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return key
+	}
+
+	// Helper function: sign and save certificate
+	signAndSaveCert := func(cert *Certificate, caKey PrivateKey, filename string) {
+		err := cert.Sign(caKey, EVP_SM3)
+		if err != nil {
+			t.Fatal(err)
+		}
+		certPem, err := cert.MarshalPEM()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = SavePEMToFile(certPem, filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create CA certificate
+	caKey, err := GenerateECKey(Sm2Curve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caInfo := CertificateInfo{
+		big.NewInt(1),
+		0,
+		87600 * time.Hour, // 10 years
+		"US",
+		"Test CA",
+		"CA",
+	}
+	caExtensions := map[NID]string{
+		NID_basic_constraints:        "critical,CA:TRUE",
+		NID_key_usage:                "critical,digitalSignature,keyCertSign,cRLSign",
+		NID_subject_key_identifier:   "hash",
+		NID_authority_key_identifier: "keyid:always,issuer",
+	}
+	ca, err := NewCertificate(&caInfo, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ca.AddExtensions(caExtensions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caFile := filepath.Join(dirName, "chain-ca.crt")
+	signAndSaveCert(ca, caKey, caFile)
+
+	// Define additional certificate information
+	certInfos := []struct {
+		name     string
+		keyUsage string
+	}{
+		{"server_enc", "keyAgreement, keyEncipherment, dataEncipherment"},
+		{"server_sign", "nonRepudiation, digitalSignature"},
+		{"client_sign", "nonRepudiation, digitalSignature"},
+		{"client_enc", "keyAgreement, keyEncipherment, dataEncipherment"},
+	}
+
+	// Create additional certificates
+	for _, info := range certInfos {
+		keyFile := filepath.Join(dirName, info.name+".key")
+		key := generateAndSaveKey(keyFile)
+		certInfo := CertificateInfo{
+			Serial:       big.NewInt(1),
+			Issued:       0,
+			Expires:      87600 * time.Hour, // 10 years
+			Country:      "US",
+			Organization: "Test",
+			CommonName:   "localhost",
+		}
+		extensions := map[NID]string{
+			NID_basic_constraints: "critical,CA:FALSE",
+			NID_key_usage:         info.keyUsage,
+		}
+		cert, err := NewCertificate(&certInfo, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = cert.AddExtensions(extensions)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = cert.SetIssuer(ca)
+		if err != nil {
+			t.Fatal(err)
+		}
+		certFile := filepath.Join(dirName, info.name+".crt")
+		signAndSaveCert(cert, caKey, certFile)
 	}
 }
 

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -112,6 +112,10 @@ type PrivateKey interface {
 	// MarshalPKCS1PrivateKeyDER converts the private key to DER-encoded PKCS1
 	// format
 	MarshalPKCS1PrivateKeyDER() (der_block []byte, err error)
+
+	// MarshalPKCS8PrivateKeyPEM converts the private key to PEM-encoded PKCS8
+	// format
+	MarshalPKCS8PrivateKeyPEM() (pem_block []byte, err error)
 }
 
 type pKey struct {
@@ -237,6 +241,31 @@ func (key *pKey) VerifyPKCS1v15(method Method, data, sig []byte) error {
 
 		return nil
 	}
+}
+
+func (key *pKey) MarshalPKCS8PrivateKeyPEM() ([]byte, error) {
+	if key.key == nil {
+		return nil, errors.New("empty key")
+	}
+
+	bio := C.BIO_new(C.BIO_s_mem())
+	if bio == nil {
+		return nil, errors.New("failed to allocate memory")
+	}
+	defer C.BIO_free(bio)
+
+	if C.PEM_write_bio_PKCS8PrivateKey(bio, key.key, nil, nil, 0, nil, nil) != 1 {
+		return nil, errors.New("failed to write private key")
+	}
+
+	var ptr *C.char
+	length := C.X_BIO_get_mem_data(bio, &ptr)
+	if length <= 0 {
+		return nil, errors.New("failed to read bio data")
+	}
+
+	result := C.GoBytes(unsafe.Pointer(ptr), C.int(length))
+	return result, nil
 }
 
 func (key *pKey) Encrypt(data []byte) ([]byte, error) {

--- a/crypto/shim.c
+++ b/crypto/shim.c
@@ -99,6 +99,10 @@ void* X_BIO_get_data(BIO* bio) {
 	return BIO_get_data(bio);
 }
 
+long X_BIO_get_mem_data(BIO *b, char **pp) {
+    return BIO_get_mem_data(b, pp);
+}
+
 EVP_MD_CTX* X_EVP_MD_CTX_new() {
 	return EVP_MD_CTX_new();
 }

--- a/crypto/shim.h
+++ b/crypto/shim.h
@@ -43,6 +43,7 @@ extern int X_BIO_read(BIO *b, void *buf, int len);
 extern int X_BIO_write(BIO *b, const void *buf, int len);
 extern BIO *X_BIO_new_write_bio();
 extern BIO *X_BIO_new_read_bio();
+extern long X_BIO_get_mem_data(BIO *b, char **pp);
 
 extern int X_BN_num_bytes(const BIGNUM *a);
 

--- a/examples/cert_gen/main.go
+++ b/examples/cert_gen/main.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"github.com/tongsuo-project/tongsuo-go-sdk/crypto"
+	"math/big"
+	"path/filepath"
+	"time"
+)
+
+const genPath = "./examples/cert_gen/"
+
+func main() {
+	// Helper function: generate and save key
+	generateAndSaveKey := func(filename string) crypto.PrivateKey {
+		key, err := crypto.GenerateECKey(crypto.Sm2Curve)
+		if err != nil {
+			panic(err)
+		}
+		pem, err := key.MarshalPKCS8PrivateKeyPEM()
+		if err != nil {
+			panic(err)
+		}
+		err = crypto.SavePEMToFile(pem, filename)
+		if err != nil {
+			panic(err)
+		}
+		return key
+	}
+
+	// Helper function: create certificate
+	createCertificate := func(info crypto.CertificateInfo, key crypto.PrivateKey, extensions map[crypto.NID]string) *crypto.Certificate {
+		cert, err := crypto.NewCertificate(&info, key)
+		if err != nil {
+			panic(err)
+		}
+		err = cert.AddExtensions(extensions)
+		if err != nil {
+			panic(err)
+		}
+		return cert
+	}
+
+	// Helper function: sign and save certificate
+	signAndSaveCert := func(cert *crypto.Certificate, caKey crypto.PrivateKey, filename string) {
+		err := cert.Sign(caKey, crypto.EVP_SM3)
+		if err != nil {
+			panic(err)
+		}
+		certPem, err := cert.MarshalPEM()
+		if err != nil {
+			panic(err)
+		}
+		err = crypto.SavePEMToFile(certPem, filename)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// Create CA certificate
+	caKey, err := crypto.GenerateECKey(crypto.Sm2Curve)
+	if err != nil {
+		panic(err)
+	}
+	caInfo := crypto.CertificateInfo{
+		Serial:       big.NewInt(1),
+		Expires:      87600 * time.Hour, // 10 years
+		Country:      "US",
+		Organization: "Test CA",
+		CommonName:   "CA",
+	}
+	caExtensions := map[crypto.NID]string{
+		crypto.NID_basic_constraints:        "critical,CA:TRUE",
+		crypto.NID_key_usage:                "critical,digitalSignature,keyCertSign,cRLSign",
+		crypto.NID_subject_key_identifier:   "hash",
+		crypto.NID_authority_key_identifier: "keyid:always,issuer",
+	}
+	ca := createCertificate(caInfo, caKey, caExtensions)
+	caFile := filepath.Join(genPath, "chain-ca.crt")
+	signAndSaveCert(ca, caKey, caFile)
+
+	// Define additional certificate information
+	certInfos := []struct {
+		name     string
+		keyUsage string
+	}{
+		{"server_enc", "keyAgreement, keyEncipherment, dataEncipherment"},
+		{"server_sign", "nonRepudiation, digitalSignature"},
+		{"client_sign", "nonRepudiation, digitalSignature"},
+		{"client_enc", "keyAgreement, keyEncipherment, dataEncipherment"},
+	}
+
+	// Create additional certificates
+	for _, info := range certInfos {
+		keyFile := filepath.Join(genPath, info.name+".key")
+		key := generateAndSaveKey(keyFile)
+		certInfo := crypto.CertificateInfo{
+			Serial:       big.NewInt(1),
+			Issued:       0,
+			Expires:      87600 * time.Hour, // 10 years
+			Country:      "US",
+			Organization: "Test",
+			CommonName:   "localhost",
+		}
+		extensions := map[crypto.NID]string{
+			crypto.NID_basic_constraints: "critical,CA:FALSE",
+			crypto.NID_key_usage:         info.keyUsage,
+		}
+		cert := createCertificate(certInfo, key, extensions)
+
+		err = cert.SetIssuer(ca)
+		if err != nil {
+			panic(err)
+		}
+		certFile := filepath.Join(genPath, info.name+".crt")
+		signAndSaveCert(cert, caKey, certFile)
+	}
+}

--- a/examples/tlcp_client/main.go
+++ b/examples/tlcp_client/main.go
@@ -28,11 +28,11 @@ func main() {
 
 	flag.StringVar(&connAddr, "conn", "127.0.0.1:443", "host:port")
 	flag.StringVar(&cipherSuite, "cipher", "ECC-SM2-SM4-CBC-SM3", "cipher suite")
-	flag.StringVar(&signCertFile, "sign_cert", "", "sign certificate file")
-	flag.StringVar(&signKeyFile, "sign_key", "", "sign private key file")
-	flag.StringVar(&encCertFile, "enc_cert", "", "encrypt certificate file")
-	flag.StringVar(&encKeyFile, "enc_key", "", "encrypt private key file")
-	flag.StringVar(&caFile, "CAfile", "", "CA certificate file")
+	flag.StringVar(&signCertFile, "sign_cert", "test/certs/sm2/client_sign.crt", "sign certificate file")
+	flag.StringVar(&signKeyFile, "sign_key", "test/certs/sm2/client_sign.key", "sign private key file")
+	flag.StringVar(&encCertFile, "enc_cert", "test/certs/sm2/client_enc.crt", "encrypt certificate file")
+	flag.StringVar(&encKeyFile, "enc_key", "test/certs/sm2/client_enc.key", "encrypt private key file")
+	flag.StringVar(&caFile, "CAfile", "test/certs/sm2/chain-ca.crt", "CA certificate file")
 
 	flag.Parse()
 

--- a/examples/tlcp_server/main.go
+++ b/examples/tlcp_server/main.go
@@ -152,11 +152,11 @@ func main() {
 	acceptAddr := ""
 
 	flag.StringVar(&acceptAddr, "accept", "127.0.0.1:443", "host:port")
-	flag.StringVar(&signCertFile, "sign_cert", "", "sign certificate file")
-	flag.StringVar(&signKeyFile, "sign_key", "", "sign private key file")
-	flag.StringVar(&encCertFile, "enc_cert", "", "encrypt certificate file")
-	flag.StringVar(&encKeyFile, "enc_key", "", "encrypt private key file")
-	flag.StringVar(&caFile, "CAfile", "", "CA certificate file")
+	flag.StringVar(&signCertFile, "sign_cert", "test/certs/sm2/server_sign.crt", "sign certificate file")
+	flag.StringVar(&signKeyFile, "sign_key", "test/certs/sm2/server_sign.key", "sign private key file")
+	flag.StringVar(&encCertFile, "enc_cert", "test/certs/sm2/server_enc.crt", "encrypt certificate file")
+	flag.StringVar(&encKeyFile, "enc_key", "test/certs/sm2/server_enc.key", "encrypt private key file")
+	flag.StringVar(&caFile, "CAfile", "test/certs/sm2/chain-ca.crt", "CA certificate file")
 
 	flag.Parse()
 

--- a/ntls_test.go
+++ b/ntls_test.go
@@ -2,11 +2,14 @@ package tongsuogo
 
 import (
 	"bufio"
+	"fmt"
 	"log"
+	"math/big"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/tongsuo-project/tongsuo-go-sdk/crypto"
 )
@@ -19,7 +22,127 @@ const (
 	testCertDir = "test/certs/sm2"
 )
 
-func TestNTLS(t *testing.T) {
+func TestCAGenerateSM2AndNTLS(t *testing.T) {
+	// Create a temporary directory to store generated keys and certificates
+	tmpDir, err := os.MkdirTemp("", "tongsuo-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Helper function: generate and save key
+	generateAndSaveKey := func(filename string) crypto.PrivateKey {
+		key, err := crypto.GenerateECKey(crypto.Sm2Curve)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pem, err := key.MarshalPKCS8PrivateKeyPEM()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = crypto.SavePEMToFile(pem, filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return key
+	}
+
+	// Helper function: sign and save certificate
+	signAndSaveCert := func(cert *crypto.Certificate, caKey crypto.PrivateKey, filename string) {
+		err := cert.Sign(caKey, crypto.EVP_SM3)
+		if err != nil {
+			t.Fatal(err)
+		}
+		certPem, err := cert.MarshalPEM()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = crypto.SavePEMToFile(certPem, filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create CA certificate
+	caKey, err := crypto.GenerateECKey(crypto.Sm2Curve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caInfo := crypto.CertificateInfo{
+		Serial:       big.NewInt(1),
+		Expires:      87600 * time.Hour, // 10 years
+		Country:      "US",
+		Organization: "Test CA",
+		CommonName:   "CA",
+	}
+	caExtensions := map[crypto.NID]string{
+		crypto.NID_basic_constraints:        "critical,CA:TRUE",
+		crypto.NID_key_usage:                "critical,digitalSignature,keyCertSign,cRLSign",
+		crypto.NID_subject_key_identifier:   "hash",
+		crypto.NID_authority_key_identifier: "keyid:always,issuer",
+	}
+	ca, err := crypto.NewCertificate(&caInfo, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ca.AddExtensions(caExtensions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Save CA certificate to tmpDir
+	caCertFile := filepath.Join(tmpDir, "chain-ca.crt")
+	signAndSaveCert(ca, caKey, caCertFile)
+
+	// Define additional certificate information
+	certInfos := []struct {
+		name     string
+		keyUsage string
+	}{
+		{"server_enc", "keyAgreement, keyEncipherment, dataEncipherment"},
+		{"server_sign", "nonRepudiation, digitalSignature"},
+		{"client_sign", "nonRepudiation, digitalSignature"},
+		{"client_enc", "keyAgreement, keyEncipherment, dataEncipherment"},
+	}
+
+	// Create additional certificates
+	for _, info := range certInfos {
+		keyFile := filepath.Join(tmpDir, fmt.Sprintf("%s.key", info.name))
+		key := generateAndSaveKey(keyFile)
+		certInfo := crypto.CertificateInfo{
+			Serial:       big.NewInt(1),
+			Issued:       0,
+			Expires:      87600 * time.Hour, // 10 years
+			Country:      "US",
+			Organization: "Test",
+			CommonName:   "localhost",
+		}
+		extensions := map[crypto.NID]string{
+			crypto.NID_basic_constraints: "critical,CA:FALSE",
+			crypto.NID_key_usage:         info.keyUsage,
+		}
+		cert, err := crypto.NewCertificate(&certInfo, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = cert.AddExtensions(extensions)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = cert.SetIssuer(ca)
+		if err != nil {
+			t.Fatal(err)
+		}
+		certFile := filepath.Join(tmpDir, fmt.Sprintf("%s.crt", info.name))
+		signAndSaveCert(cert, caKey, certFile)
+	}
+
+	t.Run("NTLS Test", func(t *testing.T) {
+		testNTLS(t, tmpDir)
+	})
+}
+
+func testNTLS(t *testing.T, tmpDir string) {
+	// Use the generated keys and certificates from tmpDir to test NTLS
 	cases := []struct {
 		cipher       string
 		signCertFile string
@@ -32,15 +155,15 @@ func TestNTLS(t *testing.T) {
 		{
 			cipher:    ECCSM2Cipher,
 			runServer: internalServer,
-			caFile:    filepath.Join(testCertDir, "chain-ca.crt"),
+			caFile:    filepath.Join(tmpDir, "chain-ca.crt"),
 		},
 		{
 			cipher:       ECDHESM2Cipher,
-			signCertFile: filepath.Join(testCertDir, "client_sign.crt"),
-			signKeyFile:  filepath.Join(testCertDir, "client_sign.key"),
-			encCertFile:  filepath.Join(testCertDir, "client_enc.crt"),
-			encKeyFile:   filepath.Join(testCertDir, "client_enc.key"),
-			caFile:       filepath.Join(testCertDir, "chain-ca.crt"),
+			signCertFile: filepath.Join(tmpDir, "client_sign.crt"),
+			signKeyFile:  filepath.Join(tmpDir, "client_sign.key"),
+			encCertFile:  filepath.Join(tmpDir, "client_enc.crt"),
+			encKeyFile:   filepath.Join(tmpDir, "client_enc.key"),
+			caFile:       filepath.Join(tmpDir, "chain-ca.crt"),
 			runServer:    internalServer,
 		},
 	}
@@ -48,7 +171,7 @@ func TestNTLS(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.cipher, func(t *testing.T) {
 			if c.runServer {
-				server, err := newNTLSServer(t, func(sslctx *Ctx) error {
+				server, err := newNTLSServer(t, tmpDir, func(sslctx *Ctx) error {
 					return sslctx.SetCipherList(c.cipher)
 				})
 
@@ -186,7 +309,174 @@ func TestNTLS(t *testing.T) {
 	}
 }
 
-func newNTLSServer(t *testing.T, options ...func(sslctx *Ctx) error) (*echoServer, error) {
+func TestNTLS(t *testing.T) {
+	cases := []struct {
+		cipher       string
+		signCertFile string
+		signKeyFile  string
+		encCertFile  string
+		encKeyFile   string
+		caFile       string
+		runServer    bool
+	}{
+		{
+			cipher:    ECCSM2Cipher,
+			runServer: internalServer,
+			caFile:    filepath.Join(testCertDir, "chain-ca.crt"),
+		},
+		{
+			cipher:       ECDHESM2Cipher,
+			signCertFile: filepath.Join(testCertDir, "client_sign.crt"),
+			signKeyFile:  filepath.Join(testCertDir, "client_sign.key"),
+			encCertFile:  filepath.Join(testCertDir, "client_enc.crt"),
+			encKeyFile:   filepath.Join(testCertDir, "client_enc.key"),
+			caFile:       filepath.Join(testCertDir, "chain-ca.crt"),
+			runServer:    internalServer,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.cipher, func(t *testing.T) {
+			if c.runServer {
+				server, err := newNTLSServer(t, testCertDir, func(sslctx *Ctx) error {
+					return sslctx.SetCipherList(c.cipher)
+				})
+
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				defer server.Close()
+				go server.Run()
+			}
+
+			ctx, err := NewCtxWithVersion(NTLS)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			if err := ctx.SetCipherList(c.cipher); err != nil {
+				t.Error(err)
+				return
+			}
+
+			if c.signCertFile != "" {
+				signCertPEM, err := os.ReadFile(c.signCertFile)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				signCert, err := crypto.LoadCertificateFromPEM(signCertPEM)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+
+				if err := ctx.UseSignCertificate(signCert); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+
+			if c.signKeyFile != "" {
+				signKeyPEM, err := os.ReadFile(c.signKeyFile)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				signKey, err := crypto.LoadPrivateKeyFromPEM(signKeyPEM)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+
+				if err := ctx.UseSignPrivateKey(signKey); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+
+			if c.encCertFile != "" {
+				encCertPEM, err := os.ReadFile(c.encCertFile)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				encCert, err := crypto.LoadCertificateFromPEM(encCertPEM)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+
+				if err := ctx.UseEncryptCertificate(encCert); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+
+			if c.encKeyFile != "" {
+				encKeyPEM, err := os.ReadFile(c.encKeyFile)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+
+				encKey, err := crypto.LoadPrivateKeyFromPEM(encKeyPEM)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+
+				if err := ctx.UseEncryptPrivateKey(encKey); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+
+			if c.caFile != "" {
+				if err := ctx.LoadVerifyLocations(c.caFile, ""); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+
+			conn, err := Dial("tcp", "127.0.0.1:4433", ctx, InsecureSkipHostVerification)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer conn.Close()
+
+			cipher, err := conn.CurrentCipher()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			t.Log("current cipher", cipher)
+
+			request := "hello tongsuo\n"
+			if _, err := conn.Write([]byte(request)); err != nil {
+				t.Error(err)
+				return
+			}
+
+			resp, err := bufio.NewReader(conn).ReadString('\n')
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			if resp != request {
+				t.Error("response data is not expected: ", resp)
+				return
+			}
+		})
+	}
+}
+
+func newNTLSServer(t *testing.T, testDir string, options ...func(sslctx *Ctx) error) (*echoServer, error) {
 	ctx, err := NewCtxWithVersion(NTLS)
 	if err != nil {
 		t.Error(err)
@@ -200,18 +490,18 @@ func newNTLSServer(t *testing.T, options ...func(sslctx *Ctx) error) (*echoServe
 		}
 	}
 
-	if err := ctx.LoadVerifyLocations(filepath.Join(testCertDir, "chain-ca.crt"), ""); err != nil {
+	if err := ctx.LoadVerifyLocations(filepath.Join(testDir, "chain-ca.crt"), ""); err != nil {
 		t.Error(err)
 		return nil, err
 	}
 
-	encCertPEM, err := os.ReadFile(filepath.Join(testCertDir, "server_enc.crt"))
+	encCertPEM, err := os.ReadFile(filepath.Join(testDir, "server_enc.crt"))
 	if err != nil {
 		t.Error(err)
 		return nil, err
 	}
 
-	signCertPEM, err := os.ReadFile(filepath.Join(testCertDir, "server_sign.crt"))
+	signCertPEM, err := os.ReadFile(filepath.Join(testDir, "server_sign.crt"))
 	if err != nil {
 		t.Error(err)
 		return nil, err
@@ -239,13 +529,13 @@ func newNTLSServer(t *testing.T, options ...func(sslctx *Ctx) error) (*echoServe
 		return nil, err
 	}
 
-	encKeyPEM, err := os.ReadFile(filepath.Join(testCertDir, "server_enc.key"))
+	encKeyPEM, err := os.ReadFile(filepath.Join(testDir, "server_enc.key"))
 	if err != nil {
 		t.Error(err)
 		return nil, err
 	}
 
-	signKeyPEM, err := os.ReadFile(filepath.Join(testCertDir, "server_sign.key"))
+	signKeyPEM, err := os.ReadFile(filepath.Join(testDir, "server_sign.key"))
 	if err != nil {
 		t.Error(err)
 		return nil, err


### PR DESCRIPTION
Supports SM2 double certificate issuance, uses a temporarily issued test certificate to validate NTLS test cases, and adds code examples for SM2 double certificate issuance.