### PR TITLE
Support ALPN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@
 
 # Dependency directories (remove the comment below to include it)
 tongsuo/
+
+crypto/test-runs/
+examples/cert_gen/
+.vscode/
+.idea/

--- a/conn.go
+++ b/conn.go
@@ -628,3 +628,14 @@ func (c *Conn) setSession(session []byte) error {
 	}
 	return nil
 }
+
+// GetALPNNegotiated returns the negotiated ALPN protocol
+func (c *Conn) GetALPNNegotiated() (string, error) {
+	var proto *C.uchar
+	var protoLen C.uint
+	C.SSL_get0_alpn_selected(c.ssl, &proto, &protoLen)
+	if protoLen == 0 {
+		return "", fmt.Errorf("no ALPN protocol negotiated")
+	}
+	return C.GoStringN((*C.char)(unsafe.Pointer(proto)), C.int(protoLen)), nil
+}

--- a/shim.h
+++ b/shim.h
@@ -55,6 +55,8 @@ extern const SSL_METHOD *X_NTLS_server_method();
 #if defined SSL_CTRL_SET_TLSEXT_HOSTNAME
 extern int sni_cb(SSL *ssl_conn, int *ad, void *arg);
 #endif
+
+extern int alpn_cb(SSL *ssl_conn, const unsigned char **out, unsigned char *outlen, const unsigned char *in, unsigned int inlen, void *arg);
 extern int X_SSL_verify_cb(int ok, X509_STORE_CTX* store);
 
 /* SSL_CTX methods */

--- a/sni.c
+++ b/sni.c
@@ -21,3 +21,9 @@ int sni_cb(SSL *con, int *ad, void *arg) {
 	void* p = SSL_CTX_get_ex_data(ssl_ctx, get_ssl_ctx_idx());
 	return sni_cb_thunk(p, con, ad, arg);
 }
+
+int alpn_cb(SSL *ssl_conn, const unsigned char **out, unsigned char *outlen, const unsigned char *in, unsigned int inlen, void *arg) {
+	SSL_CTX* ssl_ctx = SSL_get_SSL_CTX(ssl_conn);
+	void* p = SSL_CTX_get_ex_data(ssl_ctx, get_ssl_ctx_idx());
+	return alpn_cb_thunk(p, ssl_conn, (unsigned char **)out, outlen, (unsigned char *)in, inlen, arg);
+}


### PR DESCRIPTION
Added new constants, types, and functions to manage ALPN protocols.
Implemented ALPN callback functions and integrated them into the server and client examples.
Updated the Ctx struct to include an ALPN callback and provided methods to set ALPN protocols.
Enhanced the client to specify and negotiate ALPN protocols.
Added a method to retrieve the negotiated ALPN protocol from a connection.
Fixed minor typos in existing constants.