### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ make install
 Then install tongsuo-go-sdk:
 
 ```bash
-go get github.com/Tongsuo-Project/tongsuo-go-sdk
+go get github.com/tongsuo-project/tongsuo-go-sdk
 ```
 
 ### Run examples


### PR DESCRIPTION
go: downloading github.com/Tongsuo-Project/tongsuo-go-sdk v1.0.0
go: github.com/Tongsuo-Project/tongsuo-go-sdk@upgrade (v1.0.0) requires github.com/Tongsuo-Project/tongsuo-go-sdk@v1.0.0: parsing go.mod:
        module declares its path as: github.com/tongsuo-project/tongsuo-go-sdk
                but was required as: github.com/Tongsuo-Project/tongsuo-go-sdk
